### PR TITLE
add support for TLS1.2 and certs other than rsa+sha1

### DIFF
--- a/ssl-cipher-suite-enum.pl
+++ b/ssl-cipher-suite-enum.pl
@@ -47,6 +47,7 @@ options are:
   --rdp              Send RDP protocol preamble before talking SSL
   --smtp             Send SMTP STARTTLS before talking SSL
   --ftp              Send FTP AUTH SSL talking SSL
+  --mysql            Send mysql STARTTLS
   --file hosts.txt   Hosts to scan
   --outfile out.txt  Log output to file too
   --rate n           Limit to n connections/sec.  Default: unlimited
@@ -92,6 +93,7 @@ my $global_rate = undef;
 my $global_rdp = 0;
 my $global_smtp = 0;
 my $global_ftp = 0;
+my $global_mysql = 0;
 my $global_persist = 0;
 my $global_recv_timeout = 10;
 my $global_connect_fail_count = 5;
@@ -112,6 +114,7 @@ my $result = GetOptions (
          "rdp"        => \$global_rdp,
          "smtp"       => \$global_smtp,
          "ftp"        => \$global_ftp,
+         "mysql"      => \$global_mysql,
          "file=s"     => \$hostfile,
          "rate=s"     => \$global_rate,
          "timeout_recv=s"     => \$global_recv_timeout,
@@ -282,6 +285,15 @@ my $ciphersuitenamestring = "
 0x006B	TLS_DHE_RSA_WITH_AES_256_CBC_SHA256	[RFC5246]
 0x006C	TLS_DH_anon_WITH_AES_128_CBC_SHA256	[RFC5246]
 0x006D	TLS_DH_anon_WITH_AES_256_CBC_SHA256	[RFC5246]
+0x0072	TLS_DHE_DSS_WITH_3DES_EDE_CBC_RMD160	mysql.yassl
+0x0073	TLS_DHE_DSS_WITH_AES_128_CBC_RMD160	mysql.yassl
+0x0074	TLS_DHE_DSS_WITH_AES_256_CBC_RMD160	mysql.yassl
+0x0077	TLS_DHE_RSA_WITH_3DES_EDE_CBC_RMD160	mysql.yassl
+0x0078	TLS_DHE_RSA_WITH_AES_128_CBC_RMD160	mysql.yassl
+0x0079	TLS_DHE_RSA_WITH_AES_256_CBC_RMD160	mysql.yassl
+0x007C	TLS_RSA_WITH_3DES_EDE_CBC_RMD160	mysql.yassl
+0x007D	TLS_RSA_WITH_AES_128_CBC_RMD160	mysql.yassl
+0x007E	TLS_RSA_WITH_AES_256_CBC_RMD160	mysql.yassl
 0x0080  TLS_GOSTR341094_WITH_28147_CNT_IMIT http://tools.ietf.org/html/draft-chudov-cryptopro-cptls-04
 0x0081  TLS_GOSTR341001_WITH_28147_CNT_IMIT http://tools.ietf.org/html/draft-chudov-cryptopro-cptls-04
 0x0082  TLS_GOSTR341094_WITH_NULL_GOSTR3411 http://tools.ietf.org/html/draft-chudov-cryptopro-cptls-04
@@ -715,7 +727,7 @@ sub scan_host {
 	print "Port:         $port\n";
 	print "Protocols:    $protos_to_test\n";
 	print "Persist:      $global_persist\n";
-	printf "Preamble:     %s%s%s%s\n", $global_ftp ? "FTP" : "", $global_rdp ? "RDP" : "", $global_smtp ? "SMTP" : "", ($global_rdp == 0 and $global_smtp == 0 and $global_ftp == 0) ? "None" : "";
+	printf "Preamble:     %s%s%s%s%s\n", $global_mysql ? "MySQL" : "", $global_ftp ? "FTP" : "", $global_rdp ? "RDP" : "", $global_smtp ? "SMTP" : "", ($global_rdp == 0 and $global_smtp == 0 and $global_ftp == 0 and $global_mysql == 0) ? "None" : "";
 	printf "Scan Rate:    %s\n", defined($global_rate) ? $global_rate . " connections/sec" : "unlimited";
 	printf "Recv Timeout: %s\n", $global_recv_timeout;
 
@@ -1116,6 +1128,9 @@ sub get_socket {
 	if ($global_ftp) {
 		do_ftp_preamble($socket);
 	}
+	if ($global_mysql) {
+		do_mysql_preamble($socket);
+	}
 	return $socket;
 }
 
@@ -1193,6 +1208,10 @@ sub test_v3_ciphersuites {
 		@data = split("", $data);
 
 		if ($data[1] . $data[2] ne $protocol_bin) {
+			if ($global_mysql and $data[1] eq "\0" and $data[2] eq "\0") {
+				printf "[+] Cipher suite NOT supported.  Probed for %s %s\n", get_protocol_name($protocol), $ccname if $debug > 0;
+				return -1;
+			}
 			if ($global_persist) {
 				printf "[+] Protocol %s is not supported.  Continuing anyway...\n", get_protocol_name($protocol);
 			} else {
@@ -1216,7 +1235,7 @@ sub test_v3_ciphersuites {
 			my $neg_cc = sprintf("%02x%02x",ord($data[$ccpos]), ord($data[$ccpos+1]));
 			my $neg_cc_name = get_cc_name($neg_cc);
 			printf "[+] packet type (should be 0x02 for Server Hello): %02x\n", ord($data[5]) if $debug > 1;
-			printf "[+] Cipher Suite: %02x%02x\n", ord($data[44]), ord($data[45]) if $debug > 1;
+			printf "[+] Cipher Suite: %s %s\n", $neg_cc, $neg_cc_name if $debug > 1;
 #			printf "[+] Server time: %02x%02x%02x%02x\n", ord($data[11]), ord($data[12]), ord($data[13]), ord($data[14]);
 #			printf "[+] Compression: %02x\n", ord($data[46]);
 #			my $exlen = (ord($data[47]) << 8) + ord($data[48]);
@@ -1577,6 +1596,48 @@ sub do_ftp_preamble {
 
 	print "[+] FTP Preamble - Received from Server :\n"  if $debug > 1;
 	hdump($data) if $debug > 1;
+}
+
+sub do_mysql_preamble {
+	my $socket = shift;
+
+	my $data = recv_all($socket, 4);
+	return -1 unless defined($data);
+	print "[+] Mysql Initial Handshake Packet - Received from Server :\n"  if $debug > 1;
+	hdump($data) if $debug > 1;
+
+	my @data = split("", $data);
+	if (scalar(@data) > 0) {
+		my $length = ((ord($data[1]) & 0x7f) << 8) + ord($data[0]);
+		printf "[+] Mysql Initial Handshake Packet - Initial length: %d\n", $length if $debug > 1;
+		$data = recv_all($socket, $length);
+		return -1 unless defined($data);
+		hdump($data) if $debug > 1;
+	}
+
+	# my @packet = qw(
+	# 20 00 00 01 05 ae 03 00    00 00 00 01 08 00 00 00
+	# 00 00 00 00 00 00 00 00    00 00 00 00 00 00 00 00
+	# 00 00 00 00 );
+
+	my @packet = qw(
+	20 00 00 01 05 ae 0f 00    00 00 00 01 21 00 00 00
+	00 00 00 00 00 00 00 00    00 00 00 00 00 00 00 00
+	00 00 00 00 );
+
+	my $packet = join("", @packet);
+	$packet =~ s/(..)/sprintf("%c", hex($1))/ge;
+	print $socket $packet;
+
+	print "[+] Sending SSL request packet\n" if $debug > 1;
+	hdump($packet) if $debug > 1;
+
+	#my $data; # = recv_all($socket, 4);
+	#$socket->recv($data, 1024);
+	#return -1 unless defined($data);
+	#print "[+] Mysql - Received from Server :\n"  if $debug > 1;
+	#hdump($data) if $debug > 1;
+
 }
 
 # Perl Cookbook, Tie Example: Multiple Sink Filehandles


### PR DESCRIPTION
ssl-cipher-suite-enum 1.0.0 may fail for TLS1.2 when newer certificates are used, beyond the common case rsa+sha1. In my case it is rsa+sha256 on Windows IIS 7.5.

For TLS1.2 the client must say that it supports sha256 in this case, or the server doesn't offer the certificate and thus no cipher to the client.
https://www.ietf.org/rfc/rfc5246.txt
chapter 7.4.1.4.1.  Signature Algorithms

See the attached diff for a fix and more details.
